### PR TITLE
Bump min PHP version to 8.3

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -15,19 +15,14 @@ jobs:
         composer:
           - 2
         php:
-          - 7.2
-          - 7.4
-          - 7.3
-          - 8.0
-          - 8.1
-          - 8.2
           - 8.3
+          - 8.4
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install PHP
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@2.34.1
         with:
           php-version: ${{ matrix.php }}
           extensions: curl, gd, pdo_mysql, json, mbstring, pcre, session

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "imponeer/log-data-output-decorator": "^1.0",
-        "php": ">=7.1",
+        "php": ">=8.3",
         "imponeer/extension-info-contracts": "^0.1.0 || ^0.3"
     },
     "license": "MIT",


### PR DESCRIPTION
Resolves #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required PHP version to 8.3.
  * Adjusted automated testing workflows to use PHP 8.4 and a fixed version of the PHP setup action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->